### PR TITLE
fix: return err when trying to delete cluster in use

### DIFF
--- a/internal/provider/object_store_resource.go
+++ b/internal/provider/object_store_resource.go
@@ -482,10 +482,12 @@ func sendObjectStoreRequest(plan *ObjectStoreResourceModel, r *ObjectStoreResour
 	putRequest.Header.Set("Content-Type", "application/json")
 	putRequest.Header.Set("Authorization", r.httpAuthToken)
 	httpResp, err := client.Do(putRequest)
+	if httpResp != nil {
+		defer func() { _ = httpResp.Body.Close() }()
+	}
 	if err != nil {
 		return err
 	}
-	defer func() { _ = httpResp.Body.Close() }()
 	if httpResp.StatusCode >= 300 {
 		body, _ := io.ReadAll(httpResp.Body)
 		return fmt.Errorf("unable to create or update object store, got non-2xx response: %s %s", httpResp.Status, string(body))
@@ -616,12 +618,12 @@ func (r *ObjectStoreResource) Delete(ctx context.Context, req resource.DeleteReq
 	deleteRequest.Header.Set("Authorization", r.httpAuthToken)
 
 	httpResp, err := client.Do(deleteRequest)
+	if httpResp != nil {
+		defer func() { _ = httpResp.Body.Close() }()
+	}
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete object store, got error: %s", err))
 		return
-	}
-	if httpResp != nil && httpResp.Body != nil {
-		_ = httpResp.Body.Close()
 	}
 	if httpResp.StatusCode >= 300 {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete object store, got non-200 response: %d", httpResp.StatusCode))
@@ -820,10 +822,12 @@ func fetchRouterCount(client http.Client, httpEndpoint string, httpAuthToken str
 	}
 	getRequest.Header.Set("Authorization", httpAuthToken)
 	getResp, err := client.Do(getRequest)
+	if getResp != nil {
+		defer func() { _ = getResp.Body.Close() }()
+	}
 	if err != nil {
 		return 0, err
 	}
-	defer func() { _ = getResp.Body.Close() }()
 	if getResp.StatusCode >= 300 {
 		body, _ := io.ReadAll(getResp.Body)
 		return 0, fmt.Errorf("unable to fetch endpoints, got non-2xx response: %s %s", getResp.Status, string(body))
@@ -853,10 +857,12 @@ func describeObjectStore(client http.Client, name string, httpEndpoint string, h
 	}
 	getRequest.Header.Set("Authorization", httpAuthToken)
 	getResp, err := client.Do(getRequest)
+	if getResp != nil {
+		defer func() { _ = getResp.Body.Close() }()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = getResp.Body.Close() }()
 	if getResp.StatusCode == 404 {
 		return nil, nil
 	}

--- a/internal/provider/valkey_cluster_resource.go
+++ b/internal/provider/valkey_cluster_resource.go
@@ -935,7 +935,7 @@ func (r *ValkeyClusterResource) deleteClusterAndPollUntilGone(ctx context.Contex
 	if httpResp.StatusCode == 404 {
 		return nil
 	}
-	if httpResp.StatusCode >= 400 {
+	if httpResp.StatusCode == 409 {
 		return fmt.Errorf("delete request failed (%s): %s", httpResp.Status, strings.TrimSpace(string(body)))
 	}
 

--- a/internal/provider/valkey_cluster_resource.go
+++ b/internal/provider/valkey_cluster_resource.go
@@ -302,11 +302,13 @@ func (r *ValkeyClusterResource) Create(ctx context.Context, req resource.CreateR
 	postRequest.Header.Set("Content-Type", "application/json")
 	postRequest.Header.Set("Authorization", r.httpAuthToken)
 	httpResp, err := client.Do(postRequest)
+	if httpResp != nil {
+		defer func() { _ = httpResp.Body.Close() }()
+	}
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create valkey cluster, got error: %s", err))
 		return
 	}
-	defer func() { _ = httpResp.Body.Close() }()
 	if httpResp.StatusCode >= 300 {
 		body, _ := io.ReadAll(httpResp.Body)
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create valkey cluster, got non-200 response: %s %s", httpResp.Status, string(body)))
@@ -744,10 +746,12 @@ func (r *ValkeyClusterResource) updateReplicationGroup(clusterName string, nodeI
 	updateRequest.Header.Set("Content-Type", "application/json")
 
 	httpResp, err := client.Do(updateRequest)
+	if httpResp != nil {
+		defer func() { _ = httpResp.Body.Close() }()
+	}
 	if err != nil {
 		return err
 	}
-	defer func() { _ = httpResp.Body.Close() }()
 	if httpResp.StatusCode != 202 {
 		respBody, _ := io.ReadAll(httpResp.Body)
 		return fmt.Errorf("unable to update replication group, got non-202 response: %s %s", httpResp.Status, string(respBody))
@@ -780,10 +784,12 @@ func (r *ValkeyClusterResource) decreaseShardCount(clusterName string, shardCoun
 	updateRequest.Header.Set("Content-Type", "application/json")
 
 	httpResp, err := client.Do(updateRequest)
+	if httpResp != nil {
+		defer func() { _ = httpResp.Body.Close() }()
+	}
 	if err != nil {
 		return err
 	}
-	defer func() { _ = httpResp.Body.Close() }()
 	if httpResp.StatusCode != 202 {
 		respBody, _ := io.ReadAll(httpResp.Body)
 		return fmt.Errorf("unable to decrease shard count, got non-202 response: %s %s", httpResp.Status, string(respBody))
@@ -816,10 +822,12 @@ func (r *ValkeyClusterResource) increaseShardCount(clusterName string, shardCoun
 	updateRequest.Header.Set("Content-Type", "application/json")
 
 	httpResp, err := client.Do(updateRequest)
+	if httpResp != nil {
+		defer func() { _ = httpResp.Body.Close() }()
+	}
 	if err != nil {
 		return err
 	}
-	defer func() { _ = httpResp.Body.Close() }()
 	if httpResp.StatusCode != 202 {
 		respBody, _ := io.ReadAll(httpResp.Body)
 		return fmt.Errorf("unable to increase shard count, got non-202 response: %s %s", httpResp.Status, string(respBody))
@@ -855,10 +863,12 @@ func (r *ValkeyClusterResource) increaseReplicaCount(clusterName string, replica
 	updateRequest.Header.Set("Content-Type", "application/json")
 
 	httpResp, err := client.Do(updateRequest)
+	if httpResp != nil {
+		defer func() { _ = httpResp.Body.Close() }()
+	}
 	if err != nil {
 		return err
 	}
-	defer func() { _ = httpResp.Body.Close() }()
 	if httpResp.StatusCode != 202 {
 		respBody, _ := io.ReadAll(httpResp.Body)
 		return fmt.Errorf("unable to increase replication factor, got non-202 response: %s %s", httpResp.Status, string(respBody))
@@ -894,10 +904,12 @@ func (r *ValkeyClusterResource) decreaseReplicaCount(clusterName string, replica
 	updateRequest.Header.Set("Content-Type", "application/json")
 
 	httpResp, err := client.Do(updateRequest)
+	if httpResp != nil {
+		defer func() { _ = httpResp.Body.Close() }()
+	}
 	if err != nil {
 		return err
 	}
-	defer func() { _ = httpResp.Body.Close() }()
 	if httpResp.StatusCode != 202 {
 		respBody, _ := io.ReadAll(httpResp.Body)
 		return fmt.Errorf("unable to decrease replication factor, got non-202 response: %s %s", httpResp.Status, string(respBody))
@@ -913,11 +925,13 @@ func (r *ValkeyClusterResource) deleteClusterAndPollUntilGone(ctx context.Contex
 	}
 	deleteRequest.Header.Set("Authorization", r.httpAuthToken)
 	httpResp, err := client.Do(deleteRequest)
+	if httpResp != nil {
+		defer func() { _ = httpResp.Body.Close() }()
+	}
 	if err != nil {
 		return err
 	}
 	body, _ := io.ReadAll(httpResp.Body)
-	_ = httpResp.Body.Close()
 	if httpResp.StatusCode == 404 {
 		return nil
 	}
@@ -1027,10 +1041,12 @@ func describeValkeyCluster(client http.Client, name string, httpEndpoint string,
 	}
 	getRequest.Header.Set("Authorization", httpAuthToken)
 	getResp, err := client.Do(getRequest)
+	if getResp != nil {
+		defer func() { _ = getResp.Body.Close() }()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = getResp.Body.Close() }()
 	// Do not error if 404 not found
 	if getResp.StatusCode == 404 {
 		return nil, nil

--- a/internal/provider/valkey_cluster_resource.go
+++ b/internal/provider/valkey_cluster_resource.go
@@ -913,12 +913,16 @@ func (r *ValkeyClusterResource) deleteClusterAndPollUntilGone(ctx context.Contex
 	}
 	deleteRequest.Header.Set("Authorization", r.httpAuthToken)
 	httpResp, err := client.Do(deleteRequest)
-	if httpResp != nil && httpResp.Body != nil {
-		_ = httpResp.Body.Close()
+	if err != nil {
+		return err
 	}
-	if err == nil && httpResp != nil && httpResp.StatusCode == 404 {
-		// If the cluster is already gone, no need to poll
+	body, _ := io.ReadAll(httpResp.Body)
+	_ = httpResp.Body.Close()
+	if httpResp.StatusCode == 404 {
 		return nil
+	}
+	if httpResp.StatusCode >= 400 {
+		return fmt.Errorf("delete request failed (%s): %s", httpResp.Status, strings.TrimSpace(string(body)))
 	}
 
 	// Poll until the cluster is confirmed deleted (404)


### PR DESCRIPTION
Instead of timing out trying to delete a cluster that's attached to an object store, now immediately returns an error like:

```
│ Error: Cluster Deletion Failed
│ 
│ Cluster "anita-terraform-cache" deletion failed with error: delete request failed (409 Conflict): {"status":409,"title":"Precondition
│ Failed","detail":"elasticache valkey cluster with name 'anita-terraform-cache' is being used by an object store, cannot delete it"}. You may need to
│ manually delete the cluster.
```