### PR TITLE
fix: describe cluster state after update

### DIFF
--- a/internal/provider/valkey_cluster_resource.go
+++ b/internal/provider/valkey_cluster_resource.go
@@ -471,7 +471,7 @@ func (r *ValkeyClusterResource) Update(ctx context.Context, req resource.UpdateR
 				)
 				return
 			}
-			r.pollUntilClusterUpdated(ctx, plan.ClusterName.ValueString())
+			r.pollUntilClusterUpdated(ctx, plan.ClusterName.ValueString(), resp)
 		}
 	}
 
@@ -541,7 +541,7 @@ func (r *ValkeyClusterResource) Update(ctx context.Context, req resource.UpdateR
 			}
 		}
 
-		r.pollUntilClusterUpdated(ctx, plan.ClusterName.ValueString())
+		r.pollUntilClusterUpdated(ctx, plan.ClusterName.ValueString(), resp)
 	}
 
 	if diff["shard_count"] {
@@ -592,7 +592,7 @@ func (r *ValkeyClusterResource) Update(ctx context.Context, req resource.UpdateR
 			}
 		}
 
-		r.pollUntilClusterUpdated(ctx, plan.ClusterName.ValueString())
+		r.pollUntilClusterUpdated(ctx, plan.ClusterName.ValueString(), resp)
 	}
 
 	// Regardless of shard_placements, updateReplicationGroup if node_instance_type and/or enforce_shard_multi_az are updated
@@ -615,7 +615,7 @@ func (r *ValkeyClusterResource) Update(ctx context.Context, req resource.UpdateR
 			)
 			return
 		}
-		r.pollUntilClusterUpdated(ctx, plan.ClusterName.ValueString())
+		r.pollUntilClusterUpdated(ctx, plan.ClusterName.ValueString(), resp)
 	}
 
 	// Describe the cluster after all updates have been requested and asynchronously applied.
@@ -1008,8 +1008,8 @@ func (r *ValkeyClusterResource) pollUntilClusterReady(ctx context.Context, clust
 	}
 }
 
-func (r *ValkeyClusterResource) pollUntilClusterUpdated(ctx context.Context, clusterName string) {
-	// Poll until cluster status is "Active"
+func (r *ValkeyClusterResource) pollUntilClusterUpdated(ctx context.Context, clusterName string, resp *resource.UpdateResponse) {
+	// Poll until cluster status is "Active", log any other errors but do not stop polling
 	ticker := time.NewTicker(1 * time.Minute)
 	defer ticker.Stop()
 	for {
@@ -1019,7 +1019,11 @@ func (r *ValkeyClusterResource) pollUntilClusterUpdated(ctx context.Context, clu
 			return
 		case <-ticker.C:
 			foundCluster, err := describeValkeyCluster(*r.httpClient, clusterName, r.httpEndpoint, r.httpAuthToken)
-			if err != nil || foundCluster == nil {
+			if err != nil {
+				resp.Diagnostics.AddWarning("Valkey Cluster Update Error", fmt.Sprintf("Cluster \"%s\" became active with errors: %v", clusterName, err))
+				continue
+			}
+			if foundCluster == nil {
 				continue
 			}
 			if foundCluster.Status == "Active" {

--- a/internal/provider/valkey_cluster_resource.go
+++ b/internal/provider/valkey_cluster_resource.go
@@ -492,7 +492,7 @@ func (r *ValkeyClusterResource) Update(ctx context.Context, req resource.UpdateR
 				)
 				return
 			}
-			r.pollUntilClusterUpdated(ctx, plan.ClusterName.ValueString(), resp)
+			r.pollUntilClusterUpdated(ctx, plan.ClusterName.ValueString())
 		}
 	}
 
@@ -562,7 +562,7 @@ func (r *ValkeyClusterResource) Update(ctx context.Context, req resource.UpdateR
 			}
 		}
 
-		r.pollUntilClusterUpdated(ctx, plan.ClusterName.ValueString(), resp)
+		r.pollUntilClusterUpdated(ctx, plan.ClusterName.ValueString())
 	}
 
 	if diff["shard_count"] {
@@ -613,7 +613,7 @@ func (r *ValkeyClusterResource) Update(ctx context.Context, req resource.UpdateR
 			}
 		}
 
-		r.pollUntilClusterUpdated(ctx, plan.ClusterName.ValueString(), resp)
+		r.pollUntilClusterUpdated(ctx, plan.ClusterName.ValueString())
 	}
 
 	// Regardless of shard_placements, updateReplicationGroup if node_instance_type and/or enforce_shard_multi_az are updated
@@ -636,10 +636,38 @@ func (r *ValkeyClusterResource) Update(ctx context.Context, req resource.UpdateR
 			)
 			return
 		}
-		r.pollUntilClusterUpdated(ctx, plan.ClusterName.ValueString(), resp)
+		r.pollUntilClusterUpdated(ctx, plan.ClusterName.ValueString())
 	}
 
-	// Save data into Terraform state
+	foundCluster, err := describeValkeyCluster(*r.httpClient, plan.ClusterName.ValueString(), r.httpEndpoint, r.httpAuthToken)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to describe valkey cluster after update, got error: %s", err))
+		return
+	}
+	if foundCluster == nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Valkey cluster %q not found after update", plan.ClusterName.ValueString()))
+		return
+	}
+
+	plan.Id = types.StringValue(foundCluster.Name)
+	plan.ClusterName = types.StringValue(foundCluster.Name)
+	plan.NodeInstanceType = types.StringValue(foundCluster.NodeInstanceType)
+	plan.ShardCount = types.Int64Value(foundCluster.ShardCount)
+	plan.ReplicationFactor = types.Int64Value(foundCluster.ReplicationFactor)
+	plan.EnforceShardMultiAz = types.BoolValue(foundCluster.EnforceShardMultiAz)
+	plan.ShardPlacements = nil
+	for _, sp := range foundCluster.ShardPlacements {
+		replicaAZs := make([]types.String, len(sp.ReplicaAvailabilityZones))
+		for j, az := range sp.ReplicaAvailabilityZones {
+			replicaAZs[j] = types.StringValue(az)
+		}
+		plan.ShardPlacements = append(plan.ShardPlacements, ShardPlacementModel{
+			Index:                    types.Int64Value(sp.ShardIndex),
+			AvailabilityZone:         types.StringValue(sp.AvailabilityZone),
+			ReplicaAvailabilityZones: replicaAZs,
+		})
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -994,24 +1022,22 @@ func (r *ValkeyClusterResource) pollUntilClusterReady(ctx context.Context, clust
 	}
 }
 
-func (r *ValkeyClusterResource) pollUntilClusterUpdated(ctx context.Context, clusterName string, resp *resource.UpdateResponse) {
-	// Poll until cluster status is "Active", log any other errors but do not stop polling
+func (r *ValkeyClusterResource) pollUntilClusterUpdated(ctx context.Context, clusterName string) {
 	ticker := time.NewTicker(1 * time.Minute)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
-			// Context has been cancelled, stop polling
 			return
 		case <-ticker.C:
 			foundCluster, err := describeValkeyCluster(*r.httpClient, clusterName, r.httpEndpoint, r.httpAuthToken)
-			if foundCluster != nil && foundCluster.Status == "Active" {
+			if err != nil || foundCluster == nil {
+				continue
+			}
+			if foundCluster.Status == "Active" {
 				return
-			} else if err != nil || foundCluster == nil {
-				resp.Diagnostics.AddWarning("Describe after update error", fmt.Sprintf("Error: %s. Continuing to poll until cluster status is Active", err))
 			}
 		}
-
 	}
 }
 

--- a/internal/provider/valkey_cluster_resource.go
+++ b/internal/provider/valkey_cluster_resource.go
@@ -639,6 +639,9 @@ func (r *ValkeyClusterResource) Update(ctx context.Context, req resource.UpdateR
 		r.pollUntilClusterUpdated(ctx, plan.ClusterName.ValueString())
 	}
 
+	// Describe the cluster after all updates have been requested and asynchronously applied.
+	// Some updates may not have been possible, so save the state of the cluster returned from the service
+	// instead of always saving the planned terraform state.
 	foundCluster, err := describeValkeyCluster(*r.httpClient, plan.ClusterName.ValueString(), r.httpEndpoint, r.httpAuthToken)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to describe valkey cluster after update, got error: %s", err))
@@ -1023,11 +1026,13 @@ func (r *ValkeyClusterResource) pollUntilClusterReady(ctx context.Context, clust
 }
 
 func (r *ValkeyClusterResource) pollUntilClusterUpdated(ctx context.Context, clusterName string) {
+	// Poll until cluster status is "Active"
 	ticker := time.NewTicker(1 * time.Minute)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
+			// Context has been cancelled, stop polling
 			return
 		case <-ticker.C:
 			foundCluster, err := describeValkeyCluster(*r.httpClient, clusterName, r.httpEndpoint, r.httpAuthToken)

--- a/internal/provider/valkey_cluster_resource.go
+++ b/internal/provider/valkey_cluster_resource.go
@@ -630,10 +630,17 @@ func (r *ValkeyClusterResource) Update(ctx context.Context, req resource.UpdateR
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Valkey cluster %q not found after update", plan.ClusterName.ValueString()))
 		return
 	}
+	if len(foundCluster.Errors) > 0 {
+		resp.Diagnostics.AddWarning("Valkey Cluster Error", fmt.Sprintf("Found valkey cluster \"%s\" with errors: %v", foundCluster.Name, foundCluster.Errors))
+	}
 
 	populateModelFromCluster(&plan, foundCluster)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
 }
 
 func populateModelFromCluster(model *ValkeyClusterResourceModel, cluster *DescribeValkeyClustersResponseData) {
@@ -1020,7 +1027,7 @@ func (r *ValkeyClusterResource) pollUntilClusterUpdated(ctx context.Context, clu
 		case <-ticker.C:
 			foundCluster, err := describeValkeyCluster(*r.httpClient, clusterName, r.httpEndpoint, r.httpAuthToken)
 			if err != nil {
-				resp.Diagnostics.AddWarning("Valkey Cluster Update Error", fmt.Sprintf("Cluster \"%s\" became active with errors: %v", clusterName, err))
+				resp.Diagnostics.AddWarning("Describe after update error", fmt.Sprintf("Error: %s. Continuing to poll until cluster %s status is Active", err, clusterName))
 				continue
 			}
 			if foundCluster == nil {

--- a/internal/provider/valkey_cluster_resource.go
+++ b/internal/provider/valkey_cluster_resource.go
@@ -457,7 +457,11 @@ func (r *ValkeyClusterResource) Update(ctx context.Context, req resource.UpdateR
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to describe valkey cluster before update, got error: %s", err))
 		return
 	}
-	if existingCluster != nil && existingCluster.Status != "Active" {
+	if existingCluster == nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Valkey cluster %q not found, unable to update", currentState.ClusterName.ValueString()))
+		return
+	}
+	if existingCluster.Status != "Active" {
 		r.pollUntilClusterUpdated(ctx, currentState.ClusterName.ValueString(), resp)
 		if resp.Diagnostics.HasError() {
 			return
@@ -1037,10 +1041,17 @@ func (r *ValkeyClusterResource) pollUntilClusterUpdated(ctx context.Context, clu
 	for {
 		select {
 		case <-ctx.Done():
-			resp.Diagnostics.AddError(
-				"Update Timeout",
-				fmt.Sprintf("Timed out waiting for cluster %s to become Active. The cluster may still be updating. Run terraform apply again to reconcile the current state.", clusterName),
-			)
+			if ctx.Err() == context.Canceled {
+				resp.Diagnostics.AddError(
+					"Update Cancelled",
+					fmt.Sprintf("Waiting for cluster %s to become Active was cancelled: %v. The cluster may still be updating. Run terraform apply again to reconcile the current state.", clusterName, ctx.Err()),
+				)
+			} else {
+				resp.Diagnostics.AddError(
+					"Update Timeout",
+					fmt.Sprintf("Timed out waiting for cluster %s to become Active: %v. The cluster may still be updating. Run terraform apply again to reconcile the current state.", clusterName, ctx.Err()),
+				)
+			}
 			return
 		case <-ticker.C:
 			foundCluster, err := describeValkeyCluster(ctx, *r.httpClient, clusterName, r.httpEndpoint, r.httpAuthToken)
@@ -1049,7 +1060,8 @@ func (r *ValkeyClusterResource) pollUntilClusterUpdated(ctx context.Context, clu
 				continue
 			}
 			if foundCluster == nil {
-				continue
+				resp.Diagnostics.AddError("Cluster not found", fmt.Sprintf("Error: %s. The cluster %s was not found while waiting for it to become Active.", err, clusterName))
+				return
 			}
 			if foundCluster.Status == "Active" {
 				return

--- a/internal/provider/valkey_cluster_resource.go
+++ b/internal/provider/valkey_cluster_resource.go
@@ -450,6 +450,20 @@ func (r *ValkeyClusterResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
+	// If the cluster is still updating from a previous timed-out apply, wait for it to become Active
+	// before issuing new update requests, which would otherwise get a 409 Conflict.
+	existingCluster, err := describeValkeyCluster(*r.httpClient, currentState.ClusterName.ValueString(), r.httpEndpoint, r.httpAuthToken)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to describe valkey cluster before update, got error: %s", err))
+		return
+	}
+	if existingCluster != nil && existingCluster.Status != "Active" {
+		r.pollUntilClusterUpdated(ctx, currentState.ClusterName.ValueString(), resp)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	// If replication_factor is changing from nonzero to 0, enforce_shard_multi_az must be set to false first.
 	// Else it'll fail with "Invalid Argument: Must have at least 1 replica for Multi-AZ enabled Replication Group"
 	if plan.ReplicationFactor.ValueInt64() == 0 && currentState.ReplicationFactor.ValueInt64() > 0 {
@@ -618,6 +632,11 @@ func (r *ValkeyClusterResource) Update(ctx context.Context, req resource.UpdateR
 		r.pollUntilClusterUpdated(ctx, plan.ClusterName.ValueString(), resp)
 	}
 
+	// Check for timeouts/errors here so inconsistent state isn't saved
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	// Describe the cluster after all updates have been requested and asynchronously applied.
 	// Some updates may not have been possible, so save the state of the cluster returned from the service
 	// instead of always saving the planned terraform state.
@@ -637,10 +656,6 @@ func (r *ValkeyClusterResource) Update(ctx context.Context, req resource.UpdateR
 	populateModelFromCluster(&plan, foundCluster)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func populateModelFromCluster(model *ValkeyClusterResourceModel, cluster *DescribeValkeyClustersResponseData) {
@@ -1022,7 +1037,10 @@ func (r *ValkeyClusterResource) pollUntilClusterUpdated(ctx context.Context, clu
 	for {
 		select {
 		case <-ctx.Done():
-			// Context has been cancelled, stop polling
+			resp.Diagnostics.AddError(
+				"Update Timeout",
+				fmt.Sprintf("Timed out waiting for cluster %s to become Active. The cluster may still be updating. Run terraform apply again to reconcile the current state.", clusterName),
+			)
 			return
 		case <-ticker.C:
 			foundCluster, err := describeValkeyCluster(*r.httpClient, clusterName, r.httpEndpoint, r.httpAuthToken)

--- a/internal/provider/valkey_cluster_resource.go
+++ b/internal/provider/valkey_cluster_resource.go
@@ -380,28 +380,7 @@ func (r *ValkeyClusterResource) Read(ctx context.Context, req resource.ReadReque
 		resp.Diagnostics.AddWarning("Valkey Cluster Error", fmt.Sprintf("Found valkey cluster \"%s\" with errors: %v", foundCluster.Name, foundCluster.Errors))
 	}
 
-	state.Id = types.StringValue(foundCluster.Name)
-	state.ClusterName = types.StringValue(foundCluster.Name)
-	state.NodeInstanceType = types.StringValue(foundCluster.NodeInstanceType)
-	state.ShardCount = types.Int64Value(foundCluster.ShardCount)
-	state.ReplicationFactor = types.Int64Value(foundCluster.ReplicationFactor)
-	state.EnforceShardMultiAz = types.BoolValue(foundCluster.EnforceShardMultiAz)
-
-	// reset the list of shard placements before repopulating from the response
-	state.ShardPlacements = nil
-	for _, sp := range foundCluster.ShardPlacements {
-		state.ShardPlacements = append(state.ShardPlacements, ShardPlacementModel{
-			Index:            types.Int64Value(sp.ShardIndex),
-			AvailabilityZone: types.StringValue(sp.AvailabilityZone),
-			ReplicaAvailabilityZones: func() []types.String {
-				replicaAZs := make([]types.String, len(sp.ReplicaAvailabilityZones))
-				for j, az := range sp.ReplicaAvailabilityZones {
-					replicaAZs[j] = types.StringValue(az)
-				}
-				return replicaAZs
-			}(),
-		})
-	}
+	populateModelFromCluster(&state, foundCluster)
 
 	// Set refreshed state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -652,26 +631,30 @@ func (r *ValkeyClusterResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
-	plan.Id = types.StringValue(foundCluster.Name)
-	plan.ClusterName = types.StringValue(foundCluster.Name)
-	plan.NodeInstanceType = types.StringValue(foundCluster.NodeInstanceType)
-	plan.ShardCount = types.Int64Value(foundCluster.ShardCount)
-	plan.ReplicationFactor = types.Int64Value(foundCluster.ReplicationFactor)
-	plan.EnforceShardMultiAz = types.BoolValue(foundCluster.EnforceShardMultiAz)
-	plan.ShardPlacements = nil
-	for _, sp := range foundCluster.ShardPlacements {
+	populateModelFromCluster(&plan, foundCluster)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func populateModelFromCluster(model *ValkeyClusterResourceModel, cluster *DescribeValkeyClustersResponseData) {
+	model.Id = types.StringValue(cluster.Name)
+	model.ClusterName = types.StringValue(cluster.Name)
+	model.NodeInstanceType = types.StringValue(cluster.NodeInstanceType)
+	model.ShardCount = types.Int64Value(cluster.ShardCount)
+	model.ReplicationFactor = types.Int64Value(cluster.ReplicationFactor)
+	model.EnforceShardMultiAz = types.BoolValue(cluster.EnforceShardMultiAz)
+	model.ShardPlacements = nil
+	for _, sp := range cluster.ShardPlacements {
 		replicaAZs := make([]types.String, len(sp.ReplicaAvailabilityZones))
 		for j, az := range sp.ReplicaAvailabilityZones {
 			replicaAZs[j] = types.StringValue(az)
 		}
-		plan.ShardPlacements = append(plan.ShardPlacements, ShardPlacementModel{
+		model.ShardPlacements = append(model.ShardPlacements, ShardPlacementModel{
 			Index:                    types.Int64Value(sp.ShardIndex),
 			AvailabilityZone:         types.StringValue(sp.AvailabilityZone),
 			ReplicaAvailabilityZones: replicaAZs,
 		})
 	}
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
 func shardPlacementsToAPIFormat(shardPlacements []ShardPlacementModel) []map[string]interface{} {

--- a/internal/provider/valkey_cluster_resource.go
+++ b/internal/provider/valkey_cluster_resource.go
@@ -361,7 +361,7 @@ func (r *ValkeyClusterResource) Read(ctx context.Context, req resource.ReadReque
 
 	// Find valkey cluster
 	client := *r.httpClient
-	foundCluster, err := describeValkeyCluster(client, state.ClusterName.ValueString(), r.httpEndpoint, r.httpAuthToken)
+	foundCluster, err := describeValkeyCluster(ctx, client, state.ClusterName.ValueString(), r.httpEndpoint, r.httpAuthToken)
 	if err == nil && foundCluster == nil {
 		resp.Diagnostics.AddWarning("Cluster Not Found", fmt.Sprintf("Cluster with name \"%s\" not found, removing from state", state.ClusterName.ValueString()))
 		resp.State.RemoveResource(ctx)
@@ -452,7 +452,7 @@ func (r *ValkeyClusterResource) Update(ctx context.Context, req resource.UpdateR
 
 	// If the cluster is still updating from a previous timed-out apply, wait for it to become Active
 	// before issuing new update requests, which would otherwise get a 409 Conflict.
-	existingCluster, err := describeValkeyCluster(*r.httpClient, currentState.ClusterName.ValueString(), r.httpEndpoint, r.httpAuthToken)
+	existingCluster, err := describeValkeyCluster(ctx, *r.httpClient, currentState.ClusterName.ValueString(), r.httpEndpoint, r.httpAuthToken)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to describe valkey cluster before update, got error: %s", err))
 		return
@@ -640,7 +640,7 @@ func (r *ValkeyClusterResource) Update(ctx context.Context, req resource.UpdateR
 	// Describe the cluster after all updates have been requested and asynchronously applied.
 	// Some updates may not have been possible, so save the state of the cluster returned from the service
 	// instead of always saving the planned terraform state.
-	foundCluster, err := describeValkeyCluster(*r.httpClient, plan.ClusterName.ValueString(), r.httpEndpoint, r.httpAuthToken)
+	foundCluster, err := describeValkeyCluster(ctx, *r.httpClient, plan.ClusterName.ValueString(), r.httpEndpoint, r.httpAuthToken)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to describe valkey cluster after update, got error: %s", err))
 		return
@@ -1010,7 +1010,7 @@ func (r *ValkeyClusterResource) pollUntilClusterReady(ctx context.Context, clust
 			// Context has been cancelled, stop polling
 			return
 		case <-ticker.C:
-			foundCluster, err := describeValkeyCluster(*r.httpClient, clusterName, r.httpEndpoint, r.httpAuthToken)
+			foundCluster, err := describeValkeyCluster(ctx, *r.httpClient, clusterName, r.httpEndpoint, r.httpAuthToken)
 			if foundCluster != nil && foundCluster.Status == "Active" {
 				return
 			} else if foundCluster != nil && foundCluster.Status == "CreationFailed" {
@@ -1043,7 +1043,7 @@ func (r *ValkeyClusterResource) pollUntilClusterUpdated(ctx context.Context, clu
 			)
 			return
 		case <-ticker.C:
-			foundCluster, err := describeValkeyCluster(*r.httpClient, clusterName, r.httpEndpoint, r.httpAuthToken)
+			foundCluster, err := describeValkeyCluster(ctx, *r.httpClient, clusterName, r.httpEndpoint, r.httpAuthToken)
 			if err != nil {
 				resp.Diagnostics.AddWarning("Describe after update error", fmt.Sprintf("Error: %s. Continuing to poll until cluster %s status is Active", err, clusterName))
 				continue
@@ -1077,8 +1077,8 @@ type DescribeValkeyClustersResponseData struct {
 	Errors []string `json:"errors"`
 }
 
-func describeValkeyCluster(client http.Client, name string, httpEndpoint string, httpAuthToken string) (*DescribeValkeyClustersResponseData, error) {
-	getRequest, err := http.NewRequest("GET", fmt.Sprintf("%s/ec-cluster/%s", httpEndpoint, name), nil)
+func describeValkeyCluster(ctx context.Context, client http.Client, name string, httpEndpoint string, httpAuthToken string) (*DescribeValkeyClustersResponseData, error) {
+	getRequest, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/ec-cluster/%s", httpEndpoint, name), nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Updates are asynchronously applied and may run into errors. Terraform provider should not save planned state regardless of the outcome (success, failure, or timeout).

Adds one more Describe call after completing updates to ensure the reality of the cluster is saved to Terraform state instead. The Describe call at the end of Update and Read do the same thing so extracted a helper function as well.

Also adds a check at the beginning of Update to see if a previous update is still being applied so it can gracefully resume polling until it's done, then continue with remaining updates.